### PR TITLE
Feat/assume role prompt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,29 @@ FROM python:slim
 MAINTAINER Steven Jack <smaj@vidsy.co>
 
 ENV AWS_CLI_VERSION 1.10.19
-RUN pip install awscli==$AWS_CLI_VERSION
+ENV TF_VERSION 0.6.16
+ENV AWS_SDK_VERSION 2
+
+RUN pip install awscli==${AWS_CLI_VERSION}
 
 RUN apt-get update
-RUN apt-get install -y jq
+RUN apt-get install -y jq zip curl ruby
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+RUN curl -L -o /terraform.zip https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip
+RUN unzip -d /usr/local/bin /terraform.zip
+RUN chmod u+x /usr/local/bin/terraform*
+RUN mv /usr/local/bin/terraform /usr/local/bin/terraform.real
+
+RUN gem install aws-sdk -v "~> ${AWS_SDK_VERSION}"
+
 ADD assume-role.sh /usr/local/bin/assume-role
 RUN chmod u+x /usr/local/bin/assume-role
+ADD terraform-wrapper.sh /usr/local/bin/terraform
+RUN chmod u+x /usr/local/bin/terraform
+
+RUN mkdir /cwd
+WORKDIR /cwd
 
 ENTRYPOINT ["assume-role"]

--- a/assume-role.sh
+++ b/assume-role.sh
@@ -78,6 +78,7 @@ then
   export TERRAFORM_STATE_BUCKET="terraform-state.$AWS_ENV.vidsy.co"
 
   export ROLE_ID=$ROLE_ID
+  export DIRECTORY="${PWD##*/}"
 
   # ---
   # Delete .temp_credentials file

--- a/assume-role.sh
+++ b/assume-role.sh
@@ -100,8 +100,9 @@ then
   # Create new shell with env vars exported
   # ---
 
-  echo "export PS1=\"\$ENV_COLOUR\$AWS_ENV (\$ROLE_ID) \[\e[0m\]\$DIRECTORY\n> \"" >> ~/.profile.assume
+  echo "export PS1=\"\n\$ENV_COLOUR\$AWS_ENV (\$ROLE_ID) \[\e[0m\]\$DIRECTORY\n> \"" >> ~/.profile.assume
   echo ". ~/.profile" >> ~/.profile.assume
+  echo "alias t=\"terraform\"" >> ~/.profile.assume
   /bin/bash --rcfile ~/.profile.assume
 else
   echo "There was a problem assuming the role: $ASSUMED_ROLE_OUTPUT"

--- a/terraform-wrapper.sh
+++ b/terraform-wrapper.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+TIME_LEFT=$(ruby -e "require 'time'; puts ((Time.parse('$AWS_EXPIRATION') - Time.now) / 60).floor")
+if [ "$TIME_LEFT" -lt "0" ]; then
+  echo "Role has expired ($AWS_EXPIRATION), please exit this shell and start another"
+  exit -1
+fi
+
+case $1 in
+plan|apply|destroy)
+  VAR_FILE="-var-file=$AWS_ENV.tfvars"
+
+  if [ ! -f $AWS_ENV.tfvars ]; then
+    VAR_FILE=""
+  fi
+
+  STATE_FILE=$DIRECTORY
+
+  if [ -f .terraform_config ]; then
+    STATE_FILE=$(cat .terraform_config | jq -r ".remote.key")
+  fi
+
+  rm -rf .terraform/terraform.tfstate*
+  terraform.real remote config -backend=s3 -backend-config="bucket=$TERRAFORM_STATE_BUCKET" -backend-config="key=$STATE_FILE.tfstate" -backend-config="region=$AWS_REGION"
+  terraform.real $@ $VAR_FILE
+  ;;
+*)
+  terraform.real $@
+  ;;
+esac


### PR DESCRIPTION
![garf](https://cloud.githubusercontent.com/assets/527874/16036586/84422900-3214-11e6-832c-ecf11e63274d.gif)

### Problem

Currently we assume the temporary role and have to source the resulting environment variables so it's not clear which env you've assumed if you come back to the terminal. We've also restructured our terraform and the current `terraform` command needs a little massaging to work as you'd expect the tool to with our current setup.

### Solution

Create a new shell that clearly indicates the environment the user has assumed and provides the terraform binary with a wrapper script that does the following:

1. Check if assumed role has expired, if it has exit and inform the user
2. Override the `plan|apply|destroy` methods
3. Setup the remote storage, base the key on the current folder name or the key in the `.terraform_config` file if it exists.
4. Add the `var-file=ENV.tfvars` if it exists
5. Call the `terraform` binary with the apened commands and anything else the user passed in
6. Otherwise just call the `terraform` binary with whatever was passed in

> The `assume-role` script needs tidying up as it currently only supports a single role and we'd like to use it to assume any role the user has permission to.