### PR TITLE
Use state bucket name from env

### DIFF
--- a/assume-role.sh
+++ b/assume-role.sh
@@ -61,7 +61,7 @@ then
 
   EXPIRATION=$(cat ${TMP_FILE} | jq -r ".Credentials.Expiration")
   export AWS_EXPIRATION=$(ruby -e "require 'time'; puts Time.parse('$EXPIRATION').localtime")
-  export TERRAFORM_STATE_BUCKET="terraform-state.$AWS_ENV.vidsy.co"
+  export TERRAFORM_STATE_BUCKET=$TERRAFORM_STATE_BUCKET
 
   export ROLE_NAME=$ROLE_NAME
   export DIRECTORY=$DIRECTORY


### PR DESCRIPTION
### Problem

The state bucket is hardcoded to `vidsy.co`.

### Solution

Pass it into the container as in env var.