### PR TITLE
Allow varfile name to be specified externally

### DIFF
--- a/terraform-wrapper.sh
+++ b/terraform-wrapper.sh
@@ -8,10 +8,13 @@ fi
 
 case $1 in
 plan|apply|destroy)
-  VAR_FILE="-var-file=$AWS_ENV.tfvars"
 
-  if [ ! -f $AWS_ENV.tfvars ]; then
-    VAR_FILE=""
+  if [ -z "$VAR_FILE" ]; then
+    VAR_FILE="-var-file=$AWS_ENV.tfvars"
+
+    if [ ! -f $AWS_ENV.tfvars ]; then
+      VAR_FILE=""
+    fi
   fi
 
   STATE_FILE=$DIRECTORY


### PR DESCRIPTION
### Problem

Currently the `var-file` is hardcoded to expect `staging|live.tfvars` and has no flexibility for different naming conventions.

### Solution

Allow `VAR_FILE` to be externally configured, otherwise default to the existing behaviour.