### PR TITLE
Allow name of state file to be overriden

### DIFF
--- a/terraform-wrapper.sh
+++ b/terraform-wrapper.sh
@@ -17,10 +17,13 @@ plan|apply|destroy)
     fi
   fi
 
-  STATE_FILE=$DIRECTORY
 
-  if [ -f .terraform_config ]; then
-    STATE_FILE=$(cat .terraform_config | jq -r ".remote.key")
+  if [ -z "$STATE_FILE" ]; then
+    STATE_FILE=$DIRECTORY
+
+    if [ -f .terraform_config ]; then
+      STATE_FILE=$(cat .terraform_config | jq -r ".remote.key")
+    fi
   fi
 
   rm -rf .terraform/terraform.tfstate*


### PR DESCRIPTION
### Problem

The state file is either the directory name or name defined in the configuration file, would be good to be able to also override this via an environment variable.

### Solution

Check if variable is set, if not default to existing behaviour.