### PR TITLE
Bump terraform to version 0.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:slim
 MAINTAINER Steven Jack <smaj@vidsy.co>
 
 ENV AWS_CLI_VERSION 1.10.19
-ENV TF_VERSION 0.6.16
+ENV TF_VERSION 0.7.0
 ENV AWS_SDK_VERSION 2
 
 RUN pip install awscli==${AWS_CLI_VERSION}


### PR DESCRIPTION
### Problem

Terraform has now released a new version `0.7.0` and we'd like to be able to use this.

### Solution

Bump the version.