### PR TITLE
Only push to dockerhub on tag

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ test:
 
 deployment:
   hub:
-    tag: [0-9]+\.[0-9]+\.[0-9]+
+    tag: /[0-9]+\.[0-9]+\.[0-9]+/
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker tag vidsyhq/assume-role:latest vidsyhq/assume-role:$CIRCLE_TAG

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,9 @@ test:
 
 deployment:
   hub:
-    branch: master
+    tag: [0-9]+\.[0-9]+\.[0-9]+
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - docker tag vidsyhq/assume-role:latest vidsyhq/assume-role:$CIRCLE_TAG
+      - docker push vidsyhq/assume-role:$CIRCLE_TAG
       - docker push vidsyhq/assume-role


### PR DESCRIPTION
### Problem

We want to version the containers we push, it would be great if we can just tag the repo in git and this be used to tag the container and push to docker hub.

### Solution

Use circle to listen on any tag push, then push the container under `latest` and the tag to docker hub.