### PR TITLE
Bump TF to 0.7.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:slim
 MAINTAINER Steven Jack <smaj@vidsy.co>
 
 ENV AWS_CLI_VERSION 1.10.19
-ENV TF_VERSION 0.7.0
+ENV TF_VERSION 0.7.7
 ENV AWS_SDK_VERSION 2
 
 RUN pip install awscli==${AWS_CLI_VERSION}


### PR DESCRIPTION
### Problem

We're now at `0.7.7` of `terraform`, container is currently set to use `0.7.0` 😱

### Solution

* Bump it!