### PR TITLE
Bumps to v 0.7.8 to fix ELB dualstack prefix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:slim
 MAINTAINER Steven Jack <smaj@vidsy.co>
 
 ENV AWS_CLI_VERSION 1.10.19
-ENV TF_VERSION 0.7.7
+ENV TF_VERSION 0.7.8
 ENV AWS_SDK_VERSION 2
 
 RUN pip install awscli==${AWS_CLI_VERSION}


### PR DESCRIPTION
### Problem

When updating the `dc-clusters` stack the hostname was changing with a prefix of `dualstack`, which didn't cause an issue but was changing the diff each time you ran `plan`.

### Solution

A fix was applied here: https://github.com/hashicorp/terraform/pull/9704, which is included in `0.7.8`.